### PR TITLE
Use scalar query function instead of count_scalar

### DIFF
--- a/prometheus/apache-exporter-full.json
+++ b/prometheus/apache-exporter-full.json
@@ -179,7 +179,7 @@
               "step": 120
             },
             {
-              "expr": "count_scalar(apache_up{instance=~\"$host:$port\"} == 0)",
+              "expr": "scalar(count(apache_up{instance=~\"$host:$port\"} == 0))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Apache Down",


### PR DESCRIPTION
When i used the apache dashboard, this message "Parse error : unknown function with name 'count_scalar' " appeared.

https://github.com/rfrail3/grafana-dashboards/issues/25