### PR TITLE
fix stated time

### DIFF
--- a/prometheus/haproxy-2.0-full.json
+++ b/prometheus/haproxy-2.0-full.json
@@ -106,7 +106,7 @@
           },
           "targets": [
             {
-              "expr": "time() - haproxy_process_start_time_seconds",
+              "expr": "time() - haproxy_process_start_time_seconds{instance=~\"$host:$port\"}",
               "intervalFactor": 2,
               "refId": "A",
               "step": 1800


### PR DESCRIPTION
added `"$host:$port"` to prevent showing the `Only queries that return single series/table is supported` warning