### PR TITLE
haproxy: unit changed from bytes to bits

### DIFF
--- a/prometheus/haproxy-2.0-full.json
+++ b/prometheus/haproxy-2.0-full.json
@@ -444,7 +444,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -988,7 +988,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1084,7 +1084,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -4829,7 +4829,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/prometheus/haproxy-full.json
+++ b/prometheus/haproxy-full.json
@@ -364,7 +364,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -829,7 +829,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -925,7 +925,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2667,7 +2667,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "bits",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
Some panels about traffic use a query where the metric for bytes is
multiple by 8. This corresponds to 'bits' and not bytes. There two options:
remote the multiplier or change the unit. In this commit, option two has
been chosen