### PR TITLE
Update node-exporter-freebsd.json

### DIFF
--- a/prometheus/node-exporter-freebsd.json
+++ b/prometheus/node-exporter-freebsd.json
@@ -427,7 +427,7 @@
       "pluginVersion": "6.7.3",
       "targets": [
         {
-          "expr": "(node_memory_swap_used_bytes{instance=\"$node\",job=\"$job\"} * 100) / node_memory_swap_in_bytes_total{instance=\"$node\",job=\"$job\"}",
+          "expr": "(node_memory_swap_used_bytes{instance=\"$node\",job=\"$job\"} * 100) / node_memory_swap_size_bytes{instance=\"$node\",job=\"$job\"}",
           "intervalFactor": 1,
           "refId": "A",
           "step": 900


### PR DESCRIPTION
Replace 'node_memory_swap_in_bytes_total' with 'node_memory_swap_size_bytes'. Changes the calculation to ((used swap * 100) / swap size), giving used swap as a percentage of the maximum available swap.