### PR TITLE
Skip 'Filesystem in ReadOnly / Error' tmpfs errors

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -9592,7 +9592,7 @@
               "step": 4
             },
             {
-              "expr": "node_filesystem_device_error{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
+              "expr": "node_filesystem_device_error{instance=\"$node\",job=\"$job\",device!~'rootfs',fstype!~'tmpfs'}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,


### PR DESCRIPTION
Add skip for tmpfs filesystems for 'Filesystem in ReadOnly / Error' graph:

Example errors:
![image-2021-01-25-15-12-41-136](https://user-images.githubusercontent.com/2987792/105834364-0e71a880-5fd3-11eb-8188-76bdf0d17fa3.png)
