### PR TITLE
Modified diskdevice variable to also match SD card of Raspberry Pi

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -14058,8 +14058,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "[a-z]+|nvme[0-9]+n[0-9]+",
-          "value": "[a-z]+|nvme[0-9]+n[0-9]+"
+          "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
+          "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
         },
         "error": null,
         "hide": 2,
@@ -14070,11 +14070,11 @@
         "options": [
           {
             "selected": true,
-            "text": "[a-z]+|nvme[0-9]+n[0-9]+",
-            "value": "[a-z]+|nvme[0-9]+n[0-9]+"
+            "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
+            "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
           }
         ],
-        "query": "[a-z]+|nvme[0-9]+n[0-9]+",
+        "query": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
         "skipUrlSync": false,
         "type": "custom"
       }


### PR DESCRIPTION
Disk in raspberry PI is 
```
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
mmcblk0     179:0    0 14.9G  0 disk
├─mmcblk0p1 179:1    0  256M  0 part /boot
└─mmcblk0p2 179:2    0 14.6G  0 part /
```
so diskdevices variable was updated to match SD-Cards in Rasbperry Pi and so IO information is also displayed for node_exporter running on Raspberry Pi.