### PR TITLE
fix: add clamp_min to "RAM Use" calculation for avoid negative values

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -446,7 +446,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "clamp_min((1 - (node_memory_MemAvailable_bytes{instance=~\"$node.*\", job=\"$job\"} / node_memory_MemTotal_bytes{instance=~\"$node.*\", job=\"$job\"})) * 100, 0)",
+          "expr": "clamp_min((1 - (node_memory_MemAvailable_bytes{instance=\"$node\", job=\"$job\"} / node_memory_MemTotal_bytes{instance=\"$node\", job=\"$job\"})) * 100, 0)",
           "format": "time_series",
           "hide": false,
           "instant": true,


### PR DESCRIPTION
Use MemFree + Buffers + Cached instead of MemAvailable for RAM usage to avoid negative values (as in panel "Memory Basic").

Ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773