### PR TITLE
feat: Add initial, simple Alertmanager Dashboard

### DIFF
--- a/prometheus/alertmanager.json
+++ b/prometheus/alertmanager.json
@@ -1,0 +1,347 @@
+{
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "title": "Alerts",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "epm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "rate(alertmanager_alerts_received_total{instance=\"$instance\"}[$__rate_interval]) * 60",
+          "interval": "5m",
+          "legendFormat": "{{status}} ({{ version }})",
+          "refId": "A"
+        }
+      ],
+      "title": "Received Alerts (rate over 5 min)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "alertmanager_alerts{instance=\"$instance\"}",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Alerts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "epm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "rate(alertmanager_notifications_total{instance=\"$instance\"}[$__rate_interval]) * 60",
+          "legendFormat": "{{integration}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Notifications",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "title": "Cluster",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "options": {
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "alertmanager_cluster_health_score{instance=\"${instance}\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Health (0 = fully healthy)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "options": {
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "alertmanager_cluster_members{instance=\"${instance}\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Members",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "options": {
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "alertmanager_peer_position{instance=\"${instance}\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Position",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(alertmanager_cluster_messages_received_size_total{instance=\"${instance}\"}[$__rate_interval])",
+          "legendFormat": "Received {{msg_type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(alertmanager_cluster_messages_sent_size_total{instance=\"${instance}\"}[$__rate_interval])",
+          "legendFormat": "Sent {{msg_type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Message Rates (Bandwidth)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mpm"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "60 * rate(alertmanager_cluster_messages_received_total{instance=\"${instance}\"}[$__rate_interval])",
+          "legendFormat": "Received {{msg_type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "60 * rate(alertmanager_cluster_messages_sent_total{instance=\"${instance}\"}[$__rate_interval])",
+          "legendFormat": "Sent {{msg_type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Message Rates",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "title": "General Info",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "options": {
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{instance=\"${instance}\"}[$__rate_interval])",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 42,
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "Prometheus" },
+        "label": "Datasource",
+        "name": "ds_prometheus",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "allowCustomValue": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${ds_prometheus}"
+        },
+        "definition": "label_values(alertmanager_build_info,instance)",
+        "name": "instance",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(alertmanager_build_info,instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "title": "Prometheus AlertManager",
+  "uid": "24811f1c-16fc-48a4-8487-531a8a421673"
+}


### PR DESCRIPTION
Prometheus Alertmanager is part of Prometheus, so maybe a Dashboard for it could also life in this repo?

This just adds some basic stuff for the prometheus Alertmanager.

Maybe we can iterate on it with further PRs?